### PR TITLE
CAV-392 - Gateway - Passcode persisting failure & passcode verificati…

### DIFF
--- a/app/uk/gov/hmrc/cipphonenumber/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/cipphonenumber/config/AppConfig.scala
@@ -23,6 +23,8 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class AppConfig @Inject()(config: Configuration) {
 
+  lazy val httpTimeout: Long = config.getMillis("http.timeout")
+
   lazy val verificationUrlProtocol: String = config.get[String]("microservice.services.cipphonenumber.verification.protocol")
   lazy val verificationUrlHost: String = config.get[String]("microservice.services.cipphonenumber.verification.host")
   lazy val verificationUrlPort: String = config.get[String]("microservice.services.cipphonenumber.verification.port")

--- a/app/uk/gov/hmrc/cipphonenumber/connectors/VerifyConnector.scala
+++ b/app/uk/gov/hmrc/cipphonenumber/connectors/VerifyConnector.scala
@@ -25,6 +25,7 @@ import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 
 import javax.inject.{Inject, Singleton}
+import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
@@ -36,9 +37,12 @@ class VerifyConnector @Inject()(httpClientV2: HttpClientV2, config: AppConfig)
   private val notificationsUrl = s"$phoneNumberPath/notifications/%s"
   private val verifyOtpUrl = s"$phoneNumberPath/verify/otp"
 
+  private val timeout = Duration(config.httpTimeout, "milliseconds")
+
   def verify(body: JsValue)(implicit hc: HeaderCarrier): Future[HttpResponse] = {
     httpClientV2
       .post(url"$verifyUrl")
+      .transform(_.withRequestTimeout(timeout))
       .withBody(body)
       .execute[HttpResponse]
   }
@@ -46,12 +50,14 @@ class VerifyConnector @Inject()(httpClientV2: HttpClientV2, config: AppConfig)
   def status(notificationId: String)(implicit hc: HeaderCarrier): Future[HttpResponse] = {
     httpClientV2
       .get(url"${notificationsUrl.format(notificationId)}")
+      .transform(_.withRequestTimeout(timeout))
       .execute[HttpResponse]
   }
 
   def verifyOtp(body: JsValue)(implicit hc: HeaderCarrier): Future[HttpResponse] = {
     httpClientV2
       .post(url"$verifyOtpUrl")
+      .transform(_.withRequestTimeout(timeout))
       .withBody(body)
       .execute[HttpResponse]
   }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -62,6 +62,8 @@ play.i18n.langs = ["en"]
 # !!!WARNING!!! DO NOT CHANGE THIS ROUTER
 play.http.router = prod.Routes
 
+http.timeout = 30000
+
 # Metrics plugin settings - graphite reporting is configured on a per env basis
 metrics {
   name = ${appName}

--- a/test/uk/gov/hmrc/cipphonenumber/connectors/VerifyConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cipphonenumber/connectors/VerifyConnectorSpec.scala
@@ -110,6 +110,7 @@ class VerifyConnectorSpec extends AnyWordSpec
 
     private val appConfig = new AppConfig(
       Configuration.from(Map(
+        "http.timeout" -> 0,
         "microservice.services.cipphonenumber.verification.host" -> wireMockHost,
         "microservice.services.cipphonenumber.verification.port" -> wireMockPort,
         "microservice.services.cipphonenumber.verification.protocol" -> "http"


### PR DESCRIPTION
…on check failure returns incorrect status code & message

 - set http timeout to 30 seconds