### PR TITLE
CAV-445: Standardise API responses - Verify endpoint to return status…

### DIFF
--- a/app/uk/gov/hmrc/cipphonenumber/controllers/VerifyController.scala
+++ b/app/uk/gov/hmrc/cipphonenumber/controllers/VerifyController.scala
@@ -31,7 +31,12 @@ class VerifyController @Inject()(cc: ControllerComponents, verifyConnector: Veri
 
   def verify: Action[JsValue] = Action.async(parse.json) { implicit request =>
     verifyConnector.verify(request.body) map {
-      r => Status(r.status)(r.body)
+      response =>
+        val headers = response.headers.toSeq flatMap {
+          case (parameter, values) =>
+            values map (parameter -> _)
+        }
+        Status(response.status)(response.body).withHeaders(headers: _*)
     }
   }
 }

--- a/it/uk/gov/hmrc/cipphonenumber/NotificationIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/cipphonenumber/NotificationIntegrationSpec.scala
@@ -36,11 +36,11 @@ class NotificationIntegrationSpec
       //generate otp
       val verifyResponse = verify("07849123456").futureValue
 
-      val notificationId = verifyResponse.json.\("notificationId")
+      val notificationPath = verifyResponse.header("Location").get
 
       val response =
         wsClient
-          .url(s"$baseUrl/customer-insight-platform/phone-number/notifications/$notificationId")
+          .url(s"$baseUrl/customer-insight-platform/phone-number$notificationPath")
           .withRequestFilter(AhcCurlRequestLogger())
           .get
           .futureValue

--- a/test/uk/gov/hmrc/cipphonenumber/connectors/CircuitBreakerWrapperSpec.scala
+++ b/test/uk/gov/hmrc/cipphonenumber/connectors/CircuitBreakerWrapperSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.cipphonenumber.connectors
 
 import akka.stream.Materializer
-import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, get, post, stubFor, urlEqualTo}
+import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, post, stubFor, urlEqualTo}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -27,9 +27,8 @@ import play.api.libs.ws.ahc.AhcCurlRequestLogger
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.cipphonenumber.config.CircuitBreakerConfig
 import uk.gov.hmrc.cipphonenumber.utils.TestActorSystem
-import uk.gov.hmrc.http.HttpReadsInstances.readEitherOf
 import uk.gov.hmrc.http.test.{HttpClientV2Support, WireMockSupport}
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps, UpstreamErrorResponse}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
@@ -69,6 +68,7 @@ class CircuitBreakerWrapperSpec extends AnyWordSpec
     protected implicit val hc: HeaderCarrier = HeaderCarrier()
     val circuitBreakers = new CircuitBreakerWrapper {
       override def configCB: CircuitBreakerConfig = CircuitBreakerConfig("Cip Verification", 2, 60.toDuration, 60.toDuration, 60.toDuration, 1, 0)
+
       override def materializer: Materializer = Materializer(TestActorSystem.system)
     }
 

--- a/test/uk/gov/hmrc/cipphonenumber/connectors/VerifyConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cipphonenumber/connectors/VerifyConnectorSpec.scala
@@ -22,7 +22,6 @@ import org.mockito.MockitoSugar.mock
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import play.api.Configuration
 import play.api.http.Status.OK
 import play.api.libs.json.Json
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
@@ -113,9 +112,11 @@ class VerifyConnectorSpec extends AnyWordSpec
 
     implicit val hc: HeaderCarrier = HeaderCarrier()
     val cbConfigData = CircuitBreakerConfig("", 5, 5.toDuration, 30.toDuration, 5.toDuration, 1, 0)
+
     implicit class IntToDuration(timeout: Int) {
       def toDuration = Duration(timeout, java.util.concurrent.TimeUnit.SECONDS)
     }
+
     protected val appConfigMock = mock[AppConfig]
 
     when(appConfigMock.verificationConfig).thenReturn(CipVerificationConfig(


### PR DESCRIPTION
… endpoint url in the Location header

 - refactored verify response, pass headers through